### PR TITLE
Fixed setting in setup.py, which was generating a malformed package that was missing sub-modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs/_build
 
 # zipline
 .zipline
+/.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,11 @@ htmlcov
 # Translations
 *.mo
 
-# Mr Developer
+# other devops, IDE, etc.
 .mr.developer.cfg
 .project
 .pydevproject
+/.settings/
 
 # Complexity
 output/*.html
@@ -46,4 +47,3 @@ docs/_build
 
 # zipline
 .zipline
-/.settings/

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 
 
 try:
-    from setuptools import setup
+    from setuptools import setup, find_packages
 except ImportError:
-    from distutils.core import setup
+    from distutils.core import setup, find_packages
 
 
 with open('README.rst') as readme_file:
@@ -39,11 +39,7 @@ setup(
     author='Chris Pappalardo',
     author_email='cpappala@yahoo.com',
     url='https://github.com/ChrisPappalardo/stockbot',
-    packages=[
-        'stockbot',
-    ],
-    package_dir={'stockbot':
-                 'stockbot'},
+    packages=find_packages(),
     include_package_data=True,
     install_requires=requirements,
     license='CC BY-NC-ND 4.0',


### PR DESCRIPTION
Your package should now be installable via pip. In general, if it can't be installed via pip, something's very very wrong.